### PR TITLE
Cleaner sass path, watch the blog, upgrade Foundation

### DIFF
--- a/assets/scss/foundation/_foundation.scss
+++ b/assets/scss/foundation/_foundation.scss
@@ -23,8 +23,8 @@
 // --------------------------------------------------
 // Behold, here are all the Foundation components.
 
-@import '../../../node_modules/foundation-sites/scss/foundation';
-@import '../../../node_modules/motion-ui/src/motion-ui';
+@import 'node_modules/foundation-sites/scss/foundation';
+@import 'node_modules/motion-ui/src/motion-ui';
 
 @include foundation-global-styles;
 

--- a/gulp/config.yml
+++ b/gulp/config.yml
@@ -109,6 +109,6 @@ watch:
   sass: "assets/scss/**/*.scss"
   pages:
     - "*.{md,html,yml,xml}"
-    - "{_data,_includes,_layouts,_pages,_posts}/**/*.{md,html,yml,xml}"
+    - "{_data,_includes,_layouts,_pages,_posts,blog}/**/*.{md,html,yml,xml}"
     - "!_site/**/*.*"
     - "!assets/**/*.*"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "browser-sync": "^2.10.0",
     "cross-spawn": "^5.0.0",
     "del": "^2.2.2",
-    "foundation-sites": "^6.4.1",
+    "foundation-sites": "^6.4.3",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-babel": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,9 +1580,9 @@ formidable@1.0.x:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
 
-foundation-sites@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.4.1.tgz#49bbf7b59675f9690c04528f4141cd0147094532"
+foundation-sites@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.4.3.tgz#ea89eb599badf6f03dd526c51f00bdb942a844f6"
   dependencies:
     jquery ">=3.0.0"
     what-input "^4.1.3"


### PR DESCRIPTION
Slashed some periods in the `_foundation.scss` file. Everything seems to load fine, this is because npm/yarn is ran from the root I assume? 

Gulp is now watching the blog index page for changes.

And finally upgraded Foundation to 6.4.3, this also fixed the responsive accordion (as mentioned in #50).